### PR TITLE
Update Mode() for vectors without duplicates

### DIFF
--- a/R/StatsAndCIs.r
+++ b/R/StatsAndCIs.r
@@ -945,7 +945,9 @@ Mode <- function(x, na.rm=FALSE) {
   res <- fastModeX(x, narm=FALSE)
   
   if(length(res)== 0L & attr(res, "freq")==1L)
-    return(structure(NA_real_, freq = 1L))
+    # if all values are unique, fastModeX will return a res of length zero
+    # in this case all values are mode values
+    return(structure(x, freq = 1L))
   
   else
     # order results kills the attribute


### PR DESCRIPTION
If there are no duplicates in x, fastModeX will return a res of length zero and Mode() will return NA (before this commit). 
This will result in:
Mode(1:3) # returns NA
Mode(c(1:3, 1:3)) # returns 1:3
After the commit Mode() will return 1:3 for both cases. This seems more consistent to me.