### PR TITLE
Fix issue with PseudoR2

### DIFF
--- a/Example - PseudoR2 issues.R
+++ b/Example - PseudoR2 issues.R
@@ -97,7 +97,7 @@ model1.polr <- polr(ordvar ~ female + read + science, rec.df)
 which.method <- "probit"
 model2.polr <- polr(ordvar ~ female + read + science, rec.df, method = which.method)
 
-#Correct behaviour
+#Correct behaviour (these shouldn't match)
 out1.polr <- PseudoR2(model1.polr)
 out2.polr <- PseudoR2(model2.polr)
 
@@ -115,6 +115,8 @@ out3.polr
 rm(which.method)
 out4.polr <- PseudoR2(model2.polr)
 
+out2.polr
+out4.polr
 
 
 # ==== multinom ====
@@ -131,5 +133,10 @@ PseudoR2(model1.multinom)
 
 
 
+# ==== notes ===
 
+#Additional checks needed:
+#substitute, weight, and na.action parameters for each model type
+#non-literal DVs (IE, "ifelse(y_cont > =5) ~ x1 + x2)
 
+#Ensure parameters should work when they are A) explicitly defined, B) found in environment, C) not found

--- a/Example - PseudoR2 issues.R
+++ b/Example - PseudoR2 issues.R
@@ -131,12 +131,3 @@ PseudoR2(model1.multinom)
 rm(rec.df)
 PseudoR2(model1.multinom)
 
-
-
-# ==== notes ===
-
-#Additional checks needed:
-#substitute, weight, and na.action parameters for each model type
-#non-literal DVs (IE, "ifelse(y_cont > =5) ~ x1 + x2)
-
-#Ensure parameters should work when they are A) explicitly defined, B) found in environment, C) not found

--- a/Example - PseudoR2 issues.R
+++ b/Example - PseudoR2 issues.R
@@ -1,0 +1,124 @@
+library(DescTools)
+library(haven) #for read_dta
+library(MASS) #for polr
+library(nnet) #for multinom
+library(VGAM)
+
+
+##### ISSUE A #####
+#PseudoR2 computes null models based on a call to glm with no variables (" ~ .") and a "data" parameter, taken from the original model object
+#If cases are removed from the original (non-null) model based on NAs, these cases will *not* be removed from the null model
+#The null model will be fitted on a different set of data, producing a bad comparison between models
+
+## ==== Binomial logistic reg ====
+
+# ---- Working as expected ----
+hsb2 <- as.data.frame(read_dta("https://stats.idre.ucla.edu/stat/stata/notes/hsb2.dta"))
+hsb2$honcomp <- hsb2$write >= 60
+model1.logit <- glm(honcomp ~ female + read + science + ses, hsb2, family="binomial")
+out1 <- PseudoR2(model1.logit, "a")
+
+# ---- Not working as expected ----
+#now let's add missing values to ses
+hsb2$ses[hsb2$ses == 1] <- NA
+
+#Manually subset data to remove missing values
+model2.logit <- glm(honcomp ~ female + read + science + ses, subset(hsb2, ses >= 2), family="binomial")
+out2 <- PseudoR2(model2.logit, "a")
+
+#avoid manual subsetting, and instead count on the modelling process to avoid missing data
+model3.logit <- glm(honcomp ~ female + read + science + ses, hsb2, family="binomial")
+out3 <- PseudoR2(model3.logit, "a")
+
+#compare outcomes - notice they don't match
+out2
+out3
+
+# ---- Explanation ----
+
+#The log-likelihood of the main models match
+logLik(model2.logit)
+logLik(model3.logit)
+
+#However, the log-likelihood of the null models don't match
+#the calculation of likelihood for the null model works on the entire dataset specified in x$data, without removing missing values
+logLik(glm(formula = reformulate('1', 
+                                 # replace the right side of the formula by 1                                           
+                                 gsub(" .*$", "", 
+                                      # not all glms have a formula element, e.g. MASS::negbin                                           
+                                      deparse(unlist(list(model2.logit$formula, model2.logit$call$formula, formula(model2.logit)))[[1]]))),
+           # use the first non null list element
+           # note model2.logit$call$data is a symbol and must first be evaluated
+           data = Filter(Negate(is.null), list(model2.logit$data, eval(model2.logit$call$data) ))[[1]],
+           family = model2.logit$family))
+
+logLik(glm(formula = reformulate('1', 
+                                 # replace the right side of the formula by 1                                           
+                                 gsub(" .*$", "", 
+                                      # not all glms have a formula element, e.g. MASS::negbin                                           
+                                      deparse(unlist(list(model3.logit$formula, model3.logit$call$formula, formula(model3.logit)))[[1]]))),
+           # use the first non null list element
+           # note model3.logit$call$data is a symbol and must first be evaluated
+           data = Filter(Negate(is.null), list(model3.logit$data, eval(model3.logit$call$data) ))[[1]],
+           family = model3.logit$family))
+
+#Given that it is common (and often accepted) to let "glm" automatically delete missing values, this could cause incorrect evaluations of null-model log likelihood with some frequency
+#We are better off using the "model" parameter, which removes cases that are not used for analysis
+
+
+
+##### ISSUE B #####
+#Model types other than GLM generate model by running "update" on the original function call
+#This quite literally re-runs the call, referencing the *current* data object with the saved name - as well as current objects for other elements of the call
+#This will cause problems if the data frame (or another variable used in the original function call) has been changed after the original was created
+#Update will re-run the model using the *changed* variables, and produce a null model from different parameters
+
+
+# ==== POLR ====
+
+# ---- Working as expected ----
+#Generate model
+rec.df <- hsb2
+which.method <- "probit"
+rec.df$ordvar <- cut(rec.df$write, breaks = c(30,40,50,60,70))
+model1.polr <- polr(ordvar ~ female + read + science, rec.df)
+
+which.method <- "probit"
+model2.polr <- polr(ordvar ~ female + read + science, rec.df, method = which.method)
+
+#Correct behaviour
+out1.polr <- PseudoR2(model1.polr)
+out2.polr <- PseudoR2(model2.polr)
+
+# ---- Not working as expected ----
+#Let's say we then drop cases from the original data frame
+rec.df <- rec.df[!is.na(rec.df$ses),]
+rec.df[!is.na(rec.df$ses),]
+out3.polr <- PseudoR2(model1.polr)
+
+#Outcomes don't match
+out1.polr 
+out3.polr
+
+#if we delete the variable that was used to specify method, we will get an error
+rm(which.method)
+out4.polr <- PseudoR2(model2.polr)
+
+
+
+# ==== multinom ====
+
+# ---- working as expected ----
+#The same issue arises with multinom
+rec.df <- hsb2
+model1.multinom <- multinom(factor(race) ~ read + write + math, data = rec.df)
+PseudoR2(model1.multinom)
+
+#If the data frame is deleted, we can't compute PseudoR2
+rm(rec.df)
+PseudoR2(model1.multinom)
+
+
+
+
+

--- a/Example - PseudoR2 issues.R
+++ b/Example - PseudoR2 issues.R
@@ -88,7 +88,7 @@ PseudoR2(model4.logit)
 # ==== POLR ====
 
 # ---- Working as expected ----
-#Generate model
+#Generate ~fmodel
 rec.df <- hsb2
 which.method <- "probit"
 rec.df$ordvar <- cut(rec.df$write, breaks = c(30,40,50,60,70))
@@ -126,8 +126,13 @@ out4.polr
 rec.df <- hsb2
 model1.multinom <- multinom(factor(race) ~ read + write + math, data = rec.df)
 PseudoR2(model1.multinom)
+model2.multinom <- multinom(factor(race) ~ read + write + math, data = rec.df, model = TRUE)
 
 #If the data frame is deleted, we can't compute PseudoR2
 rm(rec.df)
 PseudoR2(model1.multinom)
+PseudoR2(model2.multinom)
+
+
+
 

--- a/Example - PseudoR2 issues.R
+++ b/Example - PseudoR2 issues.R
@@ -65,6 +65,17 @@ logLik(glm(formula = reformulate('1',
 #Given that it is common (and often accepted) to let "glm" automatically delete missing values, this could cause incorrect evaluations of null-model log likelihood with some frequency
 #We are better off using the "model" parameter, which removes cases that are not used for analysis
 
+# ---- Working but risky ----
+
+#Define formula externally
+logit.form <- formula(honcomp ~ female + read + science + ses)
+model4.logit <- glm(logit.form, hsb2, family="binomial")
+rm(logit.form)
+PseudoR2(model4.logit)
+
+#Pseudo-R2 checks three places for a glm formula - the second (after x$formula) is the function call
+#if this references an external object (or a changed object) we will have problems
+#The precautionary solution is to look in formula(x) before call$x$formula
 
 
 ##### ISSUE B #####

--- a/R/LinMod.R
+++ b/R/LinMod.R
@@ -283,7 +283,7 @@ PseudoR2 <- function(x, which = NULL) {
     #
     #   L.base <- logLik(update(x, ~1))
 
-    orig.formula < deparse(unlist(list(x$formula, x$call$formula, formula(x)))[[1]])
+    orig.formula < deparse(unlist(list(x$formula, formula(x), x$call$formula))[[1]])
     null.formula <- reformulate('1', gsub(" .*$", "", orig.formula))
     
     #Get all parameters that we don't explicitly know what to do with

--- a/R/LinMod.R
+++ b/R/LinMod.R
@@ -306,18 +306,18 @@ PseudoR2 <- function(x, which = NULL) {
     data <- x$model #If x has a model frame component, use that - the safest bet
   }else if(exists("data", x)){
     data <- model.frame(orig.formula, data = x$data) #If x has a data object (but no model), construct the model frame 
-    #may need to check for weights, subset, and offset parameters to be included in model.frame as well
+    #may need to check for subset, na.action, and offset parameters to be included in model.frame as well
   }else if(exists("data", x$call)){
     warning("Could not find 'model' or 'data' element of ", modeltype, " object for evaluating PseudoR2 null mode - will fit null model with new evaluation of object '", as.character(x$call$data), "'. Ensure object has not changed since initial call, or try running ", calltype.char, " with 'model = TRUE'")
     data <- model.frame(orig.formula, data = eval(x$call$data))
   } else stop("Could not find 'model' element or valid 'data' element of ", modeltype, " object for evaluating PseudoR2 null model. Try running ", calltype, " with 'model = TRUE'")
   
   #Costruct the glm call using "call", then evaluate
-  if(modeltype == "multinom") newcall <-  call(calltype.char, formula = null.formula, data = data, weights = x$weights, censored = x$censored, #specify elements that come from a known part of the polr object
+  if(modeltype == "multinom") newcall <-  call(calltype.char, formula = null.formula, data = data, weights = x$prior.weights, censored = x$censored, #specify elements that come from a known part of the polr object
                                           other_params[other_params_exist.yn]) #add unknown parameters that can be evaluated
-  else if(modeltype == "glm") newcall <- call(calltype.char, formula = null.formula, data = data, family = x$family, weights = x$weights, method = x$method, control = x$control, #specify elements that come from a known part of the glm object
+  else if(modeltype == "glm") newcall <- call(calltype.char, formula = null.formula, data = data, family = x$family, weights = x$prior.weights, method = x$method, control = x$control, #specify elements that come from a known part of the glm object
                                           other_params[other_params_exist.yn]) #add unknown parameters that can be evaluated
-  else if(modeltype == "polr") newcall <- call(calltype.char, formula = null.formula, data = data, weights = x$weights, method = x$method, #specify elements that come from a known part of the polr object
+  else if(modeltype == "polr") newcall <- call(calltype.char, formula = null.formula, data = data, weights = x$prior.weights, method = x$method, #specify elements that come from a known part of the polr object
                                           other_params[other_params_exist.yn]) #add unknown parameters that can be evaluated
   else if(modeltype == "vglm") newcall <- call("update(x, ~1)") #Avoid vglm for now
   L.base <- logLik(eval(newcall))

--- a/R/LinMod.R
+++ b/R/LinMod.R
@@ -275,7 +275,33 @@ PseudoR2 <- function(x, which = NULL) {
 
   L.full <- logLik(x)
   D.full <- -2 * L.full          # deviance(x)
-
+  AIC_score <- AIC(x)
+  BIC_score <- BIC(x)
+  
+  #Compute predicted values (do this before converting VGLM object to S3 list)
+  if(modeltype == "vglm" | modeltype == "glm"){
+    # remark Daniel Wollschlaeger, vglm would not dispatch correctly 30.11.2019
+    y.hat <- if(modeltype == "vglm") {
+      VGAM::predictvglm(x, type="link")
+    } else {
+      predict(x, type="link")
+    }
+    y.hat.resp <- predict(x, type="response")
+  }
+  
+  #For compatibility with other method types, convert vglm S4 object into normal S3 object
+  #EG, it's easier if we can consistently use x$model to access the "model" data frame
+  #Note that this needs to be done after running logLik above
+  if(modeltype == "vglm"){
+    n_vglm <- nobs(x) #save for later
+    
+    S4_xnames <- slotNames(x)
+    x <- lapply(S4_xnames, slot, object = x)
+    names(x) <- S4_xnames
+    
+    if(!is.null(x$call$form2)) stop("Cannot compute PseudoR2 values for VGLM models with form2 parameter")
+  }
+  
   orig.formula <- deparse(unlist(list(x$formula, formula(x), x$call$formula))[[1]])
   
   # ---- Get all parameters that we don't explicitly know what to do with ----
@@ -287,7 +313,13 @@ PseudoR2 <- function(x, which = NULL) {
                                                                               "model", "x", "y", "contrasts"))] #parameters that don't affect model results and can be dropped from null model call
   }else if(modeltype == "polr"){ other_params <- x$call[!(names(x$call) %in% c("formula", "data", "weights", "subset", "method",  "", #Parameters whose values are stored in model object 
                                                                               "na.action", "subset", #parameters that we can ignore if model = TRUE
-                                                                              "model", "contrasts"))]} #parameters that don't affect model results and can be dropped from null model call
+                                                                              "model", "contrasts"))] #parameters that don't affect model results and can be dropped from null model call
+  }else if(modeltype == "vglm"){ other_params <- x$call[!(names(x$call) %in% c("formula", "weights", "family", "data", "control", "", #Parameters whose values are stored in model object 
+                                                                              "na.action", "subset", #parameters that we can ignore if model = TRUE
+                                                                              "model", "contrasts", "qr.arg", "trace"))] #parameters that don't affect model results and can be dropped from null model call
+      if(nrow(x$model) == 0) stop("Can only calculate PseudoR2 for VGLM when model = TRUE, try refitting VGLM")
+  }
+  orig_call <- x$call
   
   #Check whether the other parameters, when called, will evaluate in the current environment
   other_params_exist.yn <- mapply(function(x, x.name){ #for each other_param (and the associated name)
@@ -308,7 +340,7 @@ PseudoR2 <- function(x, which = NULL) {
   
   # ---- Construct appropriate data/model object for null model call ----
   
-  calltype.char <- as.character(x$call[1])
+  calltype.char <- as.character(orig_call[1])
   
   #Get initial data
   if(exists("model", x)){
@@ -328,7 +360,7 @@ PseudoR2 <- function(x, which = NULL) {
     })
     
     if(!isValidCallRef)  stop("Could not find model, data, or valid call element of ", modeltype, " object for evaluating PseudoR2 null model (could not find '", as.character(x$call$data), "'). Try running ", calltype.char, " with 'model = TRUE'")
-    warning("Could not find model or data element of ", modeltype, " object for evaluating PseudoR2 null mode. Will fit null model with new evaluation of '", as.character(x$call$data), "'. Ensure object has not changed since initial call, or try running ", calltype.char, " with 'model = TRUE'")
+    warning("Could not find model or data element of ", modeltype, " object for evaluating PseudoR2 null model. Will fit null model with new evaluation of '", as.character(x$call$data), "'. Ensure object has not changed since initial call, or try running ", calltype.char, " with 'model = TRUE'")
     data <- eval(x$call$data)
     
   } else if(!is.null(x$call$formula)){ #if the call only references objects an environment
@@ -376,7 +408,7 @@ PseudoR2 <- function(x, which = NULL) {
       stop("Could not evaluate '", as.character(x$call$na.action), "' for fitting PseudoR2 null model with parameter na.action = ", as.character(x$call$na.action), ".  Try running ", calltype.char, " with 'model = TRUE'")
     } else if(!is.null(x$call$na.action)) warning("Re-evaluating ",  as.character(x$call$na.action), " for fitting PseudoR2 null model with parameter na.action = ", as.character(x$call$na.action))
     
-    #if we are using an object type that doesn not contain a prior.weights output, check that the weights call is valid
+    #if we are using an object type that doesn't not contain a prior.weights output, check that the weights call is valid
     #for other model types, we extract weights from the model object instead
     if(modeltype == "polr"){
       validWeights.yn <- 
@@ -388,7 +420,7 @@ PseudoR2 <- function(x, which = NULL) {
         })
       if(validWeights.yn == FALSE) stop("Could not evaluate '", as.character(x$call$weights), "' for fitting PseudoR2 null model with parameter weights = ", as.character(x$call$weights), ".  Try running ", calltype.char, " with 'model = TRUE'")
       if(!is.null(x$call$weights)) warning("Re-evaluating ", as.character(x$call$weights), " for fitting PseudoR2 null model with parameter weights = ", as.character(x$call$weights))
-
+      
       weights.call <- x$call$weights
     } else weights.call <- NULL
     
@@ -398,9 +430,15 @@ PseudoR2 <- function(x, which = NULL) {
     data <- eval(modelcall)
   }
   
-  if(!is.null(x$prior.weights)) weights <- x$prior.weights
+  if(!is.null(x$prior.weights) & length(x$prior.weights) > 0) weights <- x$prior.weights
   else if(modeltype == "multinom") weights <- x$weights #"weights' in multinom are equivalent to 'prior.weights' in glm
-  else weights = data$weights
+  else if(!is.null(data$`(weights)`) & length(data$`(weights)` > 0)) weights <- data$`(weights)`
+  else weights <- NULL
+  
+  #vglm saves prior.weights as a matrix, but then requires a vector as input
+  if(!is.null(weights) & modeltype == "vglm"){
+    if(ncol(weights) == 1) weights <- as.vector(weights) 
+  }
   
   #Drop other columns from data, to avoid literal names (eg, "factor(y)" as DV not matching any DV columns)
   data <- data[,1,drop = FALSE]
@@ -411,9 +449,11 @@ PseudoR2 <- function(x, which = NULL) {
   if(modeltype == "multinom") nullcall <- call(calltype.char, formula = null.formula, data = data, weights = weights, censored = x$censored, trace = FALSE) #specify elements that come from a known part of the multinom object
   else if(modeltype == "glm") nullcall <- call(calltype.char, formula = null.formula, data = data, weights = weights, family = x$family, method = x$method, control = x$control, offset = x$offset) #specify elements that come from a known part of the glm object
   else if(modeltype == "polr") nullcall <- call(calltype.char, formula = null.formula, data = data, weights = weights, method = x$method) #specify elements that come from a known part of the polr object
-  else if(modeltype == "vglm") nullcall <- call("update(x, ~1)") #Avoid vglm for now
-  
-  if(modeltype != "vglm" & length(other_params) > 0) nullcall[names(other_params)] <- other_params
+  else if(modeltype == "vglm"){ nullcall <- call(calltype.char, formula = null.formula, data = data, weights = weights, control = x$control, family = x$family, trace = FALSE)}
+    
+  if(length(other_params) > 0){
+    nullcall[names(other_params)] <- other_params
+  }
   L.base <- logLik(eval(nullcall))
 
   D.base <- -2 * L.base # deviance(update(x, ~1))
@@ -424,11 +464,11 @@ PseudoR2 <- function(x, which = NULL) {
   # else
   n <- attr(L.full, "nobs")   # alternative: n <- dim(x$residuals)[1]
 
-  if(inherits(x, "multinom"))
+  if(modeltype ==  "multinom")
     edf <- x$edf
-  else if(inherits(x, "vglm")){
-    edf <- x@rank
-    n <- nobs(x)  # logLik does not return nobs for vglm
+  else if(modeltype ==  "vglm"){
+    edf <- x$rank
+    n <- n_vglm  # logLik does not return nobs for vglm
   } else
     edf <- x$rank
 
@@ -447,21 +487,21 @@ PseudoR2 <- function(x, which = NULL) {
            CoxSnell=CoxSnell, Nagelkerke=Nagelkerke, AldrichNelson=NA,
            VeallZimmermann=NA,
            Efron=NA, McKelveyZavoina=NA, Tjur=NA,
-           AIC=AIC(x), BIC=BIC(x), logLik=L.full, logLik0=L.base, G2=G2)
+           AIC=AIC_score, BIC=BIC_score, logLik=L.full, logLik0=L.base, G2=G2)
 
 
-  if(inherits(x, what="glm") || inherits(x, what="vglm") ) {
+  if(modeltype == "glm" || modeltype == "vglm" ) {
 
-    if(inherits(x, what="vglm")){
-      fam <- x@family@vfamily
-      link <- if(all(x@extra$link == "logit")){
+    if(modeltype == "vglm"){
+      fam <- x$family@vfamily
+      link <- if(all(x$extra$link == "logit")){
                   "logit"
-                } else if(all(x@extra$link == "probit")){
+                } else if(all(x$extra$link == "probit")){
                   "probit"
                 } else {
                   NA
                 }
-      y <- x@y
+      y <- x$y
 
     } else {
       fam <- x$family$family
@@ -487,18 +527,11 @@ PseudoR2 <- function(x, which = NULL) {
     # McKelveyZavoina
     # y.hat <- predict(x, type="link")
     
-    # remark Daniel Wollschlaeger, vglm would not dispatch correctly 30.11.2019
-    y.hat <- if(inherits(x, "vglm")) {
-      VGAM::predictvglm(x, type="link")
-    } else {
-      predict(x, type="link")
-    }
     
     sse <- sum((y.hat - mean(y.hat))^2)
     res["McKelveyZavoina"] <- sse/(n * s2 + sse)
 
     # EfronR2
-    y.hat.resp <- predict(x, type="response")
     res["Efron"] <- (1 - (sum((y - y.hat.resp)^2)) /
                         (sum((y - mean(y))^2)))
 
@@ -508,7 +541,6 @@ PseudoR2 <- function(x, which = NULL) {
       res["Tjur"] <- unname(diff(tapply(y.hat.resp, y, mean, na.rm=TRUE)))
 
   }
-
 
   if(is.null(which))
     which <- "McFadden"

--- a/R/Tests - PseudoR2 issues.R
+++ b/R/Tests - PseudoR2 issues.R
@@ -3,6 +3,8 @@ library(haven) #for read_dta
 library(MASS) #for polr
 library(nnet) #for multinom
 library(VGAM)
+library(plyr) #for testing recode of factor, using revalue
+source("R/LinMod.R")
 
 
 # ==== notes ===
@@ -10,33 +12,33 @@ library(VGAM)
 #checks needed:
 # A) Ensure data parameter should work it is 1) explicitly defined, 2 found in environment, 3) not found
 # B) Check "special" parameters (substitute, weight, and na.action parameters)
-# C) Ensure appropriate behaviour regardless of x, y, and data parameters
-
-
-# ==== GLM ====
+# C) check non-literal variables
 
 hsb2 <- as.data.frame(read_dta("https://stats.idre.ucla.edu/stat/stata/notes/hsb2.dta"))
 hsb2$honcomp <- hsb2$write >= 60
 
-#"Data" and model objects are both safe
+
+
+# ==== GLM ====
+
+#"Data" and "model" object components are both usable (we give priority to model)
 base.logit <- glm(honcomp ~ female + read + science + ses, hsb2, family="binomial")
 PseudoR2(base.logit)
 
-#"Data" object is reference to global environment (but we have a modekl object)
+#"Data" object is reference to global environment (but we have a model object)
 base2.logit <- glm(hsb2$honcomp ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial")
 PseudoR2(base2.logit)
 
-
-# ---- A ----
+#POSSIBLE ISSUE: no model object (only data), and a non-literal DV (eg, read > 60)
 #A1 tests are covered above
 
-#A2
+#A2a - variables in global environment
 y <- hsb2$honcomp
 test_a2.logit <- glm(y ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", model = FALSE)
 PseudoR2(test_a2.logit)
+#NB: doesn't give useful name of object that needs new evaluation
 
 #A3a - "data" object is reference to global environment
-#Consider more informative error messages?
 z <- hsb2$honcomp
 test_a3a.logit <- glm(z ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", model = FALSE, x = TRUE, y = TRUE)
 rm(z)
@@ -45,9 +47,11 @@ PseudoR2(test_a3a.logit)
 #A3b - "data" object is contained in data frame
 tempdf <- hsb2
 test_a3b.logit <- glm(honcomp ~ female + read + science + ses, tempdf, family="binomial", model = FALSE)
+PseudoR2(test_a3b.logit)
+tempdf <- tempdf[1:100,]
+PseudoR2(test_a3b.logit)
 rm(tempdf)
 PseudoR2(test_a3b.logit)
-
 
 
 # ---- B ----
@@ -55,10 +59,11 @@ PseudoR2(test_a3b.logit)
 #Weights are created on-the-fly via runif
 test_b1.logit <- glm(honcomp ~ female + read + science + ses, hsb2, family="binomial", weights = runif(nrow(hsb2)), model = FALSE)
 PseudoR2(test_b1.logit)
+PseudoR2(test_b1.logit)
 
 #Weights are saved
 test_weights <- runif(nrow(hsb2))
-test_b2.logit <- glm(hsb2$honcomp ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", weights = test_weights, model = FALSE)
+test_b2.logit <- glm(honcomp ~ female + read + science + ses, data = hsb2, family="binomial", weights = test_weights, model = FALSE)
 rm(test_weights)
 PseudoR2(test_b2.logit)
 
@@ -66,11 +71,8 @@ withna.df <- rbind(hsb2[1:100,], NA, NA, hsb2[101:200,])
 test_b3.logit <- glm(honcomp ~ female + read + science + ses, data = withna.df, family="binomial", weights = runif(nrow(withna.df)), model = FALSE)
 PseudoR2(test_b3.logit)
 
-#What happens if weight is combined with subset/na's? We're fine if we have a model parameter, or the original data parameter
-#However, if "data" referneces an environment or is omitted, it's possible that weight will be the wrong length
-#This will generate an error so its okay (a re-sorted dataframe is the main risk, but we generate a warning for this)
-
 #NA.ACTION
+#Could try using the na.omit attribute of glms here to handle, but it's a lot of work for little return
 test_b4.logit <- glm(honcomp ~ female + read + science + ses, data = rbind(hsb2, NA), family="binomial", model = FALSE, na.action = na.omit)
 PseudoR2(test_b4.logit)
 
@@ -85,8 +87,198 @@ rm(test_naAction)
 PseudoR2(test_b6.logit)
 
 
+# ---- C ----
+
+#DV, With model
+test_c1.logit <- glm((hsb2$write_cat == "(30,40]" | hsb2$write_cat == "(40,50]") ~ female + read + science + ses, hsb2, family="binomial")
+PseudoR2(test_c1.logit)
+
+#DV, without model, out of data frame
+test_c2.logit <- glm((hsb2$write_cat == "(30,40]" | hsb2$write_cat == "(40,50]") ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", model = FALSE)
+PseudoR2(test_c2.logit)
+
+#DV, without model, in data frmae
+test_c3.logit <- glm((write_cat == "(30,40]" | hsb2$write_cat == "(40,50]") ~ female + read + science + ses, hsb2, family="binomial", model = FALSE)
+PseudoR2(test_c3.logit)
+
+#IV, without model, no data frame
+test_c4.logit <- glm(hsb2$honcomp ~ hsb2$female + (hsb2$read > 50) + hsb2$science + hsb2$ses, family="binomial", model = FALSE)
+PseudoR2(test_c4.logit)
+
+#IV, without model, with data frame
+test_c5.logit <- glm(honcomp ~ female + (read > 50) + science + ses, family="binomial", data = hsb2, model = FALSE)
+PseudoR2(test_c5.logit)
+
+
+# ==== POLR ====
+
+hsb2$write_cat <- cut(hsb2$write, breaks = c(30,40,50,60,70))
+
+#"Data" and "model" object components are both usable (we give priority to model)
+base.polr <- polr(write_cat ~ female + read + science + ses, hsb2)
+PseudoR2(base.polr)
+
+# ---- A ----
+
+#A1: polr does not return "data" component, so explicit reference is impossible
+
+#A2: polr object "call" component references valid data frame
+#Unlike in glm, polr doesn't save a data object
+test_a2.polr <- polr(write_cat ~ female + read + science + ses, hsb2, model = FALSE)
+PseudoR2(test_a2.polr)
+
+#POSSIBLE ISSUE: no model object (only data), and a non-literal DV (eg, read > 60)
+
+#A3
+#"call" references objects in global environment
+#NOTE: could theoretically get the variables from call$formula, althiugh this would be risky
+y <- cut(hsb2$write, breaks = c(30,40,50,60,70))
+test_a3a.polr <- polr(y ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, model = FALSE)
+PseudoR2(test_a3a.polr)
+
+#A3b - "call" references invalid data frame
+tempdf <- hsb2
+test_a3b.polr <- polr(write_cat ~ female + read + science + ses, data = tempdf, model = FALSE)
+rm(tempdf)
+PseudoR2(test_a3b.polr)
 
 
 
-# ---- 
+# ---- B ----
+#WEIGHTS
+#Weights are created on-the-fly via runif
+test_b1.polr <- polr(write_cat ~ female + read + science + ses, hsb2, weights = runif(nrow(hsb2)), model = FALSE)
+PseudoR2(test_b1.polr)
+
+#Weights are saved
+test_weights <- runif(nrow(hsb2))
+test_b2.polr <- polr(write_cat ~ female + read + science + ses, weights = test_weights, data = hsb2, model = FALSE)
+PseudoR2(test_b2.polr)
+rm(test_weights)
+PseudoR2(test_b2.polr)
+
+withna.df <- rbind(hsb2[1:100,], NA, NA, hsb2[101:200,])
+test_b3.polr <- polr(write_cat ~ female + read + science + ses, data = withna.df, weights = runif(nrow(withna.df)), model = FALSE)
+PseudoR2(test_b3.polr)
+
+#NA.ACTION
+test_b4.polr <- polr(write_cat ~ female + read + science + ses, data = rbind(hsb2, NA), model = FALSE, na.action = na.omit)
+PseudoR2(test_b4.polr)
+
+test_naAction <- na.omit
+test_b5.polr <-  polr(write_cat~ female + read + science + ses, data = rbind(hsb2, NA), model = TRUE, na.action = test_naAction)
+PseudoR2(test_b5.polr)
+test_naAction <- na.fail
+PseudoR2(test_b5.polr)
+
+test_naAction <- na.omit
+test_b6.logit <-  glm(honcomp ~ female + read + science + ses, data = rbind(hsb2, NA), family="binomial", model = FALSE, na.action = test_naAction)
+PseudoR2(test_b6.logit)
+test_naAction <- na.fail
+PseudoR2(test_b6.logit)
+
+# ---- C ----
+
+
+#DV, without model, out of data frame
+test_c1.polr <- polr(revalue(write_cat, c("(30,40]" = "(30,50]", "(40,50]" = "(30,50]")) ~ female + read + science + ses, hsb2, model = FALSE)
+PseudoR2(test_c1.polr)
+
+#DV, without model, in data frmae
+test_c2.polr <- polr(revalue(hsb2$write_cat, c("(30,40]" = "(30,50]", "(40,50]" = "(30,50]")) ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, model = FALSE)
+PseudoR2(test_c2.polr)
+
+#IV, without model, no data frame
+test_c3.polr <- polr(hsb2$write_cat ~ hsb2$female + (hsb2$read > 50) + hsb2$science + hsb2$ses, model = FALSE)
+PseudoR2(test_c3.polr)
+
+#IV, without model, with data frame
+test_c4.polr <- polr(write_cat ~ female + (read > 50) + science + ses, hsb2, model = FALSE)
+PseudoR2(test_c4.polr)
+
+
+# ==== Multinom ====
+
+hsb2$race_cat <- factor(hsb2$race)
+
+#"Data" and "model" object components are both usable (we give priority to model)
+base.multinom <- multinom(race_cat ~ female + read + science + ses, hsb2, model = TRUE)
+PseudoR2(base.multinom)
+
+# ---- A ----
+
+#A1: multinom does not return "data" component, so expciCit reference is impossible
+
+#A2: multinom object "call" component references valid data frame
+test_a2.multinom <- multinom(race_cat ~ female + read + science + ses, hsb2, model = FALSE)
+PseudoR2(test_a2.multinom)
+
+#A3
+#Unlike in glm, multinom won't save an enviornment labelled as "data"
+#"call" references objects in global environment
+#NOTE: could theoretically get the variables from call$formula, althiugh this would be risky
+y_nominal <- hsb2$race_cat
+test_a3a.multinom <- multinom(y_nominal ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, model = FALSE)
+PseudoR2(test_a3a.multinom)
+
+#A3b - "call" references invalid data frame
+tempdf <- hsb2
+test_a3b.multinom <- multinom(race_cat ~ female + read + science + ses, data = tempdf, model = FALSE)
+PseudoR2(test_a3b.multinom)
+rm(tempdf)
+PseudoR2(test_a3b.multinom)
+
+
+
+# ---- B ----
+#WEIGHTS
+#Weights are created on-the-fly via runif
+#Multinom saves a "weights" element, which is equivalent to the glm "prior.weights" element
+test_b1.multinom <- multinom(race_cat ~ female + read + science + ses, hsb2, weights = runif(nrow(hsb2)), model = TRUE)
+PseudoR2(test_b1.multinom)
+
+#Weights are saved
+test_weights <- runif(nrow(hsb2))
+test_b2.multinom <- multinom(race_cat ~ female + read + science + ses, weights = test_weights, data = hsb2, model = FALSE)
+PseudoR2(test_b2.multinom)
+rm(test_weights)
+PseudoR2(test_b2.multinom)
+
+withna.df <- rbind(hsb2[1:100,], NA, NA, hsb2[101:200,])
+test_b3.multinom <- multinom(race_cat  ~ female + read + science + ses, data = withna.df, weights = runif(nrow(withna.df)), model = FALSE)
+PseudoR2(test_b3.multinom)
+
+#NA.ACTION
+test_b4.multinom <- multinom(race_cat  ~ female + read + science + ses, data = rbind(hsb2, NA), model = FALSE, na.action = na.omit)
+PseudoR2(test_b4.multinom)
+
+test_naAction <- na.omit
+test_b5.multinom <-  multinom(race_cat ~ female + read + science + ses, data = rbind(hsb2, NA), model = TRUE, na.action = test_naAction)
+PseudoR2(test_b5.multinom)
+test_naAction <- na.fail
+PseudoR2(test_b5.multinom)
+
+#QUIETLY RE-FIT MULTINOM
+
+# ---- C ----
+
+#DV, With model
+test_c1.multinom <- multinom(revalue(race_cat, c("1" = "1", "2" = "1")) ~ female + read + science + ses, hsb2, model = TRUE)
+PseudoR2(test_c1.multinom)
+
+#DV, without model, out of data frame
+test_c2.multinom <- multinom(revalue(hsb2$race_cat, c("1" = "1", "2" = "1")) ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, model = FALSE)
+PseudoR2(test_c2.multinom)
+
+#DV, without model, in data frame
+test_c2.multinom <- multinom(revalue(race_cat, c("1" = "1", "2" = "1")) ~ female + read + science + ses, hsb2, model = FALSE)
+PseudoR2(test_c2.multinom)
+
+#IV, without model, no data frame
+test_c4.multinom <- multinom(hsb2$race_cat ~ hsb2$female + (hsb2$read > 50) + hsb2$science + hsb2$ses, model = FALSE)
+PseudoR2(test_c4.multinom)
+
+#IV, without model, with data frame
+test_c5.multinom <- multinom(race_cat ~ female + (read > 50) + science + ses, data = hsb2, model = FALSE)
+PseudoR2(test_c5.multinom)
 

--- a/R/Tests - PseudoR2 issues.R
+++ b/R/Tests - PseudoR2 issues.R
@@ -1,0 +1,92 @@
+library(DescTools)
+library(haven) #for read_dta
+library(MASS) #for polr
+library(nnet) #for multinom
+library(VGAM)
+
+
+# ==== notes ===
+
+#checks needed:
+# A) Ensure data parameter should work it is 1) explicitly defined, 2 found in environment, 3) not found
+# B) Check "special" parameters (substitute, weight, and na.action parameters)
+# C) Ensure appropriate behaviour regardless of x, y, and data parameters
+
+
+# ==== GLM ====
+
+hsb2 <- as.data.frame(read_dta("https://stats.idre.ucla.edu/stat/stata/notes/hsb2.dta"))
+hsb2$honcomp <- hsb2$write >= 60
+
+#"Data" and model objects are both safe
+base.logit <- glm(honcomp ~ female + read + science + ses, hsb2, family="binomial")
+PseudoR2(base.logit)
+
+#"Data" object is reference to global environment (but we have a modekl object)
+base2.logit <- glm(hsb2$honcomp ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial")
+PseudoR2(base2.logit)
+
+
+# ---- A ----
+#A1 tests are covered above
+
+#A2
+y <- hsb2$honcomp
+test_a2.logit <- glm(y ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", model = FALSE)
+PseudoR2(test_a2.logit)
+
+#A3a - "data" object is reference to global environment
+#Consider more informative error messages?
+z <- hsb2$honcomp
+test_a3a.logit <- glm(z ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", model = FALSE, x = TRUE, y = TRUE)
+rm(z)
+PseudoR2(test_a3a.logit)
+
+#A3b - "data" object is contained in data frame
+tempdf <- hsb2
+test_a3b.logit <- glm(honcomp ~ female + read + science + ses, tempdf, family="binomial", model = FALSE)
+rm(tempdf)
+PseudoR2(test_a3b.logit)
+
+
+
+# ---- B ----
+#WEIGHTS
+#Weights are created on-the-fly via runif
+test_b1.logit <- glm(honcomp ~ female + read + science + ses, hsb2, family="binomial", weights = runif(nrow(hsb2)), model = FALSE)
+PseudoR2(test_b1.logit)
+
+#Weights are saved
+test_weights <- runif(nrow(hsb2))
+test_b2.logit <- glm(hsb2$honcomp ~ hsb2$female + hsb2$read + hsb2$science + hsb2$ses, family="binomial", weights = test_weights, model = FALSE)
+rm(test_weights)
+PseudoR2(test_b2.logit)
+
+withna.df <- rbind(hsb2[1:100,], NA, NA, hsb2[101:200,])
+test_b3.logit <- glm(honcomp ~ female + read + science + ses, data = withna.df, family="binomial", weights = runif(nrow(withna.df)), model = FALSE)
+PseudoR2(test_b3.logit)
+
+#What happens if weight is combined with subset/na's? We're fine if we have a model parameter, or the original data parameter
+#However, if "data" referneces an environment or is omitted, it's possible that weight will be the wrong length
+#This will generate an error so its okay (a re-sorted dataframe is the main risk, but we generate a warning for this)
+
+#NA.ACTION
+test_b4.logit <- glm(honcomp ~ female + read + science + ses, data = rbind(hsb2, NA), family="binomial", model = FALSE, na.action = na.omit)
+PseudoR2(test_b4.logit)
+
+test_naAction <- na.omit
+test_b5.logit <-  glm(honcomp ~ female + read + science + ses, data = rbind(hsb2, NA), family="binomial", model = TRUE, na.action = test_naAction)
+rm(test_naAction)
+PseudoR2(test_b5.logit)
+
+test_naAction <- na.omit
+test_b6.logit <-  glm(honcomp ~ female + read + science + ses, data = rbind(hsb2, NA), family="binomial", model = FALSE, na.action = test_naAction)
+rm(test_naAction)
+PseudoR2(test_b6.logit)
+
+
+
+
+
+# ---- 
+


### PR DESCRIPTION
## Problem ##

There are two related issues with the way `PseudoR2` creates null models. Both these issues affect the likelihood scores for the null model, and therefore the computations for PseudoR2; they will result in potentially incorrect calculations. 

**Issue A:**` PseudoR2` computes null models for `glm` objects based on a new call to `glm` with no variables (" ~ .") and a "data" parameter, taken from the original model object. If cases are removed from the original (non-null) model based on `NA`s in independent variables, these cases will *not* be removed from the null model. The null model will be fitted on a different set of data, producing a bad comparison between models. If other parameters are specified in the original `glm `call, they will be ignored in the new call.

**Issue B:** Model types other than GLM generate model by running `update` on the original function call. This literally re-runs the call, searching for the named data frame in the *current* environment. This will cause problems if the data frame (or another variable used in the original function call) has been changed or deleted after the original was created. The model will be r-run using the *changed* variables or parameters, and produce a null model that is not comparable with the original model.

This is illustrated in the `Example - PseudoR2 issues.R` file in the project (this is for illustration only, and is not intended for final inclusion in the package).

## Proposed Solution ##
I have suggested a new, and somewhat involved, way to calculate null models. This constructs a *new* function call, ideally using the data stored in the model object. The first preference is to take data from the `model `parameter, which provides a "processed" data frame from `model.matrix` - including any dropped case, weights, offsets, and so on. The second preference is to take unprocessed data from the `data` parameter. If this is done, we re-run `model.frame` to drop cases (and associated weights) as appropriate. The third is to search environments for the named data object.

Some other parts of the function call are also stored in objects, and can be retrieved (for example, `weight`, `subset`, and `offset`). This approach is taken whenever possible. I have manually defined a list of parameters that are saved in `glm`, `multinom`, `polr`, and `vglm` objects, but may be missing some. For parameters that are *not* saved (or where we are not aware of a saved location, I attempt to evaluate the parameter in the current environment. If it evaluates, we proceed; if not, we drop the parameter and proceed with a warning.

These changes also mean that `PseudoR2` now works with weighted data. If there is a principled reason why you chose *not* to allow weighted data in the function, this should be easy enough to disable.

## Uncertainties ##
The approach here has attempted to let `PseudoR2` run in as many circumstances as possible, whenever it is *reasonably* likely that we can produce a correct result. This involves generating a fair number of warning messages, and hoping users will take them seriously. An alternate approach would be to only allow `PseudoR2` for models that were called with `model = TRUE` (in other words, where there is a saved copy of the original data, and we can be sure that the correct null model will be constructed). This will lead to more error messages, and more instances which the function does not work - but will also avoid misuse.

A second caveat is for `vglm `models. Because these models are more general, it is more difficult to specify the correct null model calls for them. For example, the `form2`parameter is likely to cause difficulties. The current version of `PseudoR2` causes errors for some of the sample models listed in the `vglm` documentation, likely because of the difficulties in reconstructing complex function calls. I have ensured that my changes do not break any of the currently-functioning `PseudoR2 `calls with `vglm` models, but have not corrected all the other errors (I am not that experienced with the vglm package). More generally, the number of possible varieties of `vglm` model make it more difficult to test all possible use cases.

I have included a file `Tests - PseudoR2 issues.R` to test the changes with in a variety of circumstances. I have tried to be thorough, but welcome other ideas for testing and debugging.