### PR TITLE
Update R-CMD-check for R 4.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '3.6'}
-          - {os: macOS-latest, r: '3.6'}
-          - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: windows-latest, r: '4.0'}
+          - {os: macOS-latest, r:   '4.0'}
+          - {os: macOS-latest, r:   'devel'}
+          - {os: ubuntu-16.04, r:   '4.0', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: '4.0'}
+          - {os: windows-latest, r: 'devel'}
           - {os: macOS-latest, r:   '4.0'}
-          - {os: macOS-latest, r:   'devel'}
           - {os: ubuntu-16.04, r:   '4.0', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:


### PR DESCRIPTION
The current version of R-CMD-check fails on GitHub due to changes in setup files that are related to the new version of R (released on Friday). I updated the setup to pass R-CMD-check tests on R 4.0.