### PR TITLE
Make GitHub automatically update readme.md if readme.Rmd is changed

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    paths:
+      - README.Rmd
+
+name: Render README
+
+jobs:
+  render:
+    name: Render README
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Install rmarkdown
+        run: Rscript -e 'install.packages("rmarkdown")'
+      - name: Render README
+        run: Rscript -e 'rmarkdown::render("README.Rmd")'
+      - name: Commit results
+        run: |
+          git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"


### PR DESCRIPTION
This is an additional setup that makes GitHub Actions to automatically update `readme.md` file if any changes in `readme.Rmd`  were introduced. In the case of new changes, GitHub Actions render  `readme.Rmd` into `readme.md` and commit changes to the GitHub repository.