### PR TITLE
Update README.Rmd according to DescTools-package.Rd (v0.99.35)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -74,11 +74,11 @@ Hence the use of these functions is restricted to *Windows* systems.
 ```{r, eval=FALSE}
 install.packages("RDCOMClient", repos="http://www.omegahat.net/R")
 ```
-The *omegahat* repository does not benefit from the same update service as CRAN.
-So you may be forced to install a package compiled with an earlier version, which usually is not a problem.
-Use, e.g., for R 3.6x:
+The *omegahat* repository does not benefit from the same update service as CRAN. So you may be forced to install a package compiled with an earlier version, which usually is not a problem.
+Use e.g. for R 3.6.x/R 4.0:
 ```{r, eval=FALSE}
 url <- "http://www.omegahat.net/R/bin/windows/contrib/3.5.1/RDCOMClient_0.93-0.zip"
+url <- "http://www.omegahat.net/R/bin/windows/contrib/4.0/RDCOMClient_0.94-0.zip"
 install.packages(url, repos = NULL, type = "binary")
 ```
 


### PR DESCRIPTION
I detected some changes in `DescTools-package.Rd` when **DescTools** 0.99.35 was released on CRAN. I updated `README.Rmd` accordingly.  

*In the future,* I think we have to find an automatic way to update `README.Rmd` accorning to changes in `DescTools-package.Rd` as it is a double work to update everything manually.