### PR TITLE
Fix GitHub Actions settings

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,6 +79,7 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
+          _R_CHECK_FORCE_SUGGESTS_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,15 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '4.0'}
+          - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'devel'}
-          - {os: macOS-latest, r:   '4.0'}
-          - {os: ubuntu-16.04, r:   '4.0', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: macOS-latest,   r: 'release'}
+          - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      _R_CHECK_FORCE_SUGGESTS_: false
       RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
@@ -42,6 +43,7 @@ jobs:
         run: |
           install.packages('remotes')
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
       - name: Cache R packages
@@ -49,8 +51,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -67,11 +69,23 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
+      - name: Session info
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
+
       - name: Check
         env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          _R_CHECK_CRAN_INCOMING_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,12 +1,16 @@
 on:
   push:
-    branches: master
+    branches:
+      - master
+      - enable_automatic_checking
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: windows-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -18,19 +22,20 @@ jobs:
         run: |
           install.packages('remotes')
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
       - name: Cache R packages
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: macOS-r-3.6-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: macOS-r-3.6-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install dependencies
         run: |
           install.packages("remotes")
-          install.packages("http://www.omegahat.net/R/bin/windows/contrib/3.5.1/RDCOMClient_0.93-0.zip", repos = NULL, type="binary")
+          install.packages("http://www.omegahat.net/R/bin/windows/contrib/4.0/RDCOMClient_0.94-0.zip", repos = NULL, type="binary")
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS="true")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_dev("pkgdown")

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,7 +8,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: windows-latest
+    runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,118 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+<!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version-last-release/DescTools)](https://CRAN.R-project.org/package=DescTools)
+[![downloads](https://cranlogs.r-pkg.org/badges/grand-total/DescTools)](https://CRAN.R-project.org/package=DescTools)
+[![downloads](http://cranlogs.r-pkg.org/badges/last-week/DescTools)](https://CRAN.R-project.org/package=DescTools)
+[![License: GPL v2+](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+[![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
+[![R build status](https://github.com/AndriSignorell/DescTools/workflows/R-CMD-check/badge.svg)](https://github.com/AndriSignorell/DescTools/actions)
+<!-- badges: end -->
+
+
+# Tools for Descriptive Statistics and Exploratory Data Analysis
+
+**DescTools** is an extensive collection of miscellaneous basic statistics functions and comfort wrappers not available in the R basic system for efficient description of data.
+The author's intention was to create a toolbox, which facilitates the (notoriously time consuming) first descriptive tasks in data analysis, consisting of calculating descriptive statistics, drawing graphical summaries and reporting the results.
+The package contains furthermore functions to produce documents using MS Word (or PowerPoint) and functions to import data from Excel.
+
+A considerable part of the included functions can be found scattered in other packages and other sources written partly by Titans of R.
+The reason for collecting them here, was primarily to have them consolidated in ONE instead of dozens of packages (which themselves might depend on other packages, which are not needed at all), and to provide a common and consistent interface as far as function and arguments naming, `NA` handling, recycling rules etc. are concerned.
+Google style guides were used as naming rules (in absence of convincing alternatives).
+The 'CamelStyle' was consequently applied to functions borrowed from contributed R packages as well.
+
+Feedback, feature requests, bug reports and other suggestions are welcome!
+Please report problems to to [GitHub issues tracker](https://github.com/AndriSignorell/DescTools/issues) (preferred), Stack Overflow mentioning **DescTools** or directly to the maintainer.
+
+
+## Installation
+
+You can install the released version of **DescTools** from [CRAN](https://CRAN.R-project.org) with:
+
+```{r, eval=FALSE}
+install.packages("DescTools")
+```
+
+And the development version from GitHub with:
+
+```{r, eval=FALSE}
+if (!require("remotes")) install.packages("remotes")
+remotes::install_github("AndriSignorell/DescTools")
+```
+
+
+# Warning
+
+**Warning:** This package is still under development.
+Although the code seems meanwhile quite stable, until release of version 1.0
+you should be aware that everything in the package might be subject to change.
+Backward compatibility is not yet guaranteed.
+Functions may be deleted or renamed and new syntax may be inconsistent with earlier versions.
+By release of version 1.0 the "deprecated-defunct process" will be installed.
+
+
+# MS-Office
+
+To make use of MS-Office features, you must have Office in one of its variants installed.
+All `Wrd*`, `XL*` and `Pp*` functions require the package **RDCOMClient** to be installed as well.
+Hence the use of these functions is restricted to *Windows* systems.
+**RDCOMClient** can be installed with: 
+
+```{r, eval=FALSE}
+install.packages("RDCOMClient", repos="http://www.omegahat.net/R")
+```
+The *omegahat* repository does not benefit from the same update service as CRAN. So you may be forced to install a package compiled with an earlier version, which usually is not a problem.
+Use e.g. for R 3.6.x/R 4.0:
+```{r, eval=FALSE}
+url <- "http://www.omegahat.net/R/bin/windows/contrib/3.5.1/RDCOMClient_0.93-0.zip"
+url <- "http://www.omegahat.net/R/bin/windows/contrib/4.0/RDCOMClient_0.94-0.zip"
+install.packages(url, repos = NULL, type = "binary")
+```
+
+**RDCOMClient** does not exist for Mac or Linux, sorry.
+
+
+# Authors
+
+Andri Signorell  
+Helsana Versicherungen AG, Health Sciences, Zurich  
+HWZ University of Applied Sciences in Business Administration Zurich.  
+
+R is a community project.
+This can be seen from the fact that this package includes R source code and/or documentation previously published by [various authors and contributors](https://github.com/AndriSignorell/DescTools).
+<!-- This link will work after pkgdown website for DescTools is deployed. -->
+Special thanks go to Beat Bruengger, Mathias Frueh, Daniel Wollschlaeger for their valuable contributions and testing.
+The good things come from all these guys, any problems are likely due to my tweaking.
+Thank you all!
+
+**Maintainer:** Andri Signorell
+
+
+# Examples
+
+```{r}
+library(DescTools)
+```
+
+<!-- ## Demo "describe" -->
+```{r demo-describe, error=TRUE, fig.width=6, fig.height=4, eval=FALSE}
+demo(describe, package = "DescTools")
+```
+
+<!-- ## Demo "plots" -->
+```{r demo-plots, fig.width=6, fig.height=4, error=TRUE, eval=FALSE}
+demo(plots, package = "DescTools")
+```

--- a/README.Rmd
+++ b/README.Rmd
@@ -103,7 +103,7 @@ Thank you all!
 
 # Examples
 
-```{r}
+```{r eval=FALSE}
 library(DescTools)
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ install.packages("RDCOMClient", repos="http://www.omegahat.net/R")
 
 The *omegahat* repository does not benefit from the same update service
 as CRAN. So you may be forced to install a package compiled with an
-earlier version, which usually is not a problem. Use, e.g., for R 3.6x:
+earlier version, which usually is not a problem. Use e.g. for R 3.6.x/R
+4.0:
 
 ``` r
 url <- "http://www.omegahat.net/R/bin/windows/contrib/3.5.1/RDCOMClient_0.93-0.zip"
+url <- "http://www.omegahat.net/R/bin/windows/contrib/4.0/RDCOMClient_0.94-0.zip"
 install.packages(url, repos = NULL, type = "binary")
 ```
 


### PR DESCRIPTION
This PR fixes issues related to the setting of GitHub actions.
It also closes #44.

Files:

- [x] README.Rmd is restored so README.Rmd rendering into REAMDE.md does not fail.
- [x] settings that build _pkgdown_ website fixed (on _my branch_ the failure is in the deployment phase. This is expected as the correct deployment occurs only on the default branch).
- [x] R-CMD-CHECK settings work as expected. Currently, checking fails for the old release of R (3.6.3, guess), but this is a problem of **DescTools** and not of the GitHub Actions settings.
![image](https://user-images.githubusercontent.com/12725868/84033024-e92b1e00-a9a0-11ea-9e2b-3207055bb2fb.png) 
The error is in the examples and, I think, is related to the old behavior of `data.frame()` and `stingsAsFactor`:
![image](https://user-images.githubusercontent.com/12725868/84033173-21326100-a9a1-11ea-9dfc-dd696a1ed47a.png)

@AndriSignorell If you wish, I can disable checking for the old release of R. But I think, **DescTools** should support al least one previous minor version of R.

