### PR TITLE
Fix issue with computed Median

### DIFF
--- a/R/StatsAndCIs.r
+++ b/R/StatsAndCIs.r
@@ -522,6 +522,7 @@ Quantile <- function(x, weights = NULL, probs = seq(0, 1, 0.25),
   if(isTRUE(na.rm)){
     indices <- !is.na(x)
     x <- x[indices]
+    n <- length(x)
     if(!is.null(weights)) weights <- weights[indices]
   }
   # sort values and weights (if requested)


### PR DESCRIPTION
Looking at the code for Median and the Quantile function it points to, I think the issue is that n is determined at the start of the function (line 497) prior to detection/removal of NA values. I've added a line replacing the n after removing the NA values. 

I think this would close #67