### PR TITLE
[pkgdown] Add button to switch between versions of documentation

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -10,9 +10,17 @@ template:
 
 navbar:
   structure:
-    left:  [home, intro, reference, articles, tutorials, news]
+    left:  [version, home, intro, reference, articles, tutorials, news]
     right: [github]
   components:
+    version:
+      icon: fa-book
+      menu:
+      - text: "Documentation for version of package:"
+      - text: Released
+        href: https://andrisignorell.github.io/DescTools/
+      - text: In-development
+        href: https://andrisignorell.github.io/DescTools/dev/
     articles:
       text: Tutorials
       menu:


### PR DESCRIPTION
Add button in `pkgdown` website to switch between documentation of released and in-development version of the package.

![image](https://user-images.githubusercontent.com/12725868/113334989-0c0e3080-932d-11eb-8176-aff5298faac7.png)
