### PR TITLE
Fix Perfect Agreement Criteria in Marginal Homogeneity Tests

### DIFF
--- a/R/Tests.r
+++ b/R/Tests.r
@@ -2807,7 +2807,8 @@ StuartMaxwellTest <- function (x, y = NULL) {
   # get the marginals
   rowsums <- rowSums(x)
   colsums <- colSums(x)
-  equalsums <- rowsums == colsums
+  # Ensuring perfect agreement is selected only - excluding elements with perfect disagreement by looking at covariance diag entry=0
+  equalsums <- rowsums+colsums-2*diag(x)==0
 
   if(any(equalsums)) {
     # dump any categories with perfect agreement


### PR DESCRIPTION
Ensuring that the row/columns are dropped are only where there is perfect agreement.  Complete agreement in i implies row/col i will be 0 in covariance matrix and redundant. Each i where there is perfect agreement will reduce the rank of covariance matrix by 1 - therefore removing these is correct.

The condition that I have changed is the exact condition used by Maxwell in the 1970 paper to specify covariance[i,j] where i==j so the condition is clear.

However, currently comparing row and column sums includes values where off-diagonal elements are equal. We need x[i,i]=rowSums(x)[i]=colSums(x)[i]. Cases where x[i,i]!=colSums(x)[i] means there are at least 2 off-diagonal values>0 in x[i,] and x[,i].

Including these values in contingency tables, x, is important because they have knock on impact on the covariance matrix for other row/columns. Example provided in the issues - if disagreement frequency is symmetric and large, removing these elements from the contingency table will distort agreement on the off-diagonal row/columns.

This makes agreement more comprehensive and needed for accuracy in fringe cases where there is some and equal 'disagreement' to not bias the covariance matrix generated.