### PR TITLE
fix LogStInv()'s  "log10()" bug

### DIFF
--- a/R/DescTools.r
+++ b/R/DescTools.r
@@ -2842,13 +2842,12 @@ LogStInv <- function (x, base=NULL, threshold = NULL) {
   if(is.null(base)) base <- attr(x, "base")
 
   res <- rep(NA, length(x))
-  idx <- (x < log10(threshold))
+  idx <- (x < (lgth <- log(threshold, base)))
   idx.na <- is.na(idx)
-  res[idx & !idx.na] <- threshold - threshold * log(base) *( log(x = threshold, base=base) - x[idx & !idx.na])
+  res[ idx & !idx.na] <- threshold - (threshold * log(base)) * (lgth - x[idx & !idx.na]) 
   res[!idx & !idx.na] <- base^(x[!idx & !idx.na])
 
   return(res)
-
 }
 
 

--- a/tests/misc.R
+++ b/tests/misc.R
@@ -114,3 +114,9 @@ z <- as.numeric(names(w <- table(x)))
 stopifnot(AllIdentical(Median(z, weights=w), Median(x), median(x), Median(c(x, NA, NA), na.rm=TRUE)))
 
 
+## LogStInv() was wrong for base != 10
+x <- seq(0, 10, by=1/4)
+tx <- LogSt(x, base=2, threshold=6)
+x. <- LogStInv(tx)
+all.equal(x, x., tol = 0) # gave 0.15144. before bug fix
+stopifnot(all.equal(x, x., tol = 1e-14))


### PR DESCRIPTION
`LogStInv()` contains  a `log10(.)`  which really must be a  `log(., base)`