### PR TITLE
Fix missing function reference: `Triangular`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,6 +59,7 @@ Authors@R: c(
   person("Friederich"    , "Leisch",              role = c("ctb")),
   person("Jim"           , "Lemon",               role = c("ctb")),
   person("Dong"          , "Li",                  role = c("ctb")),
+  person("Xingchi"       , "Li",                  role = c("ctb")),
   person("Martin"        , "Maechler",            role = c("ctb")),
   person("Arni"          , "Magnusson",           role = c("ctb")),
   person("Ben"           , "Mainwaring",          role = c("ctb")),

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -554,6 +554,7 @@ reference:
      - dOrder
      - dRevGumbel
      - dRevWeibull
+     - dTri
 #     - _RevGumbelExp
 
 # ~ Finance Functions --------------------------------------------------------


### PR DESCRIPTION
It seems that a triangular distributed is added recently but the function reference is missing in `pkgdown`.

Context: https://github.com/AndriSignorell/DescTools/actions/runs/7089435248/job/19294169702